### PR TITLE
Bug #59

### DIFF
--- a/modules-classes/MDLKPIOnTimeResultClient.cls
+++ b/modules-classes/MDLKPIOnTimeResultClient.cls
@@ -122,8 +122,8 @@ Public Function load_record(rg_record As Range)
     Set obj_kpi_on_time_result_client = New KPIOnTimeResultClient
     
       ' date and time
-    obj_kpi_on_time_result_client.str_date = rg_record.Offset(0, INT_OFFSET_DATE).Value
-    obj_kpi_on_time_result_client.str_time = rg_record.Offset(0, INT_OFFSET_TIME).Value
+    obj_kpi_on_time_result_client.str_date = Format(rg_record.Offset(0, INT_OFFSET_DATE).Value, "DD.MM.YYYY")
+    obj_kpi_on_time_result_client.str_time = Format(rg_record.Offset(0, INT_OFFSET_TIME).Value, "hh:mm:ss")
       ' shift
     obj_kpi_on_time_result_client.str_shift = rg_record.Offset(0, INT_OFFSET_SHIFT).Value
       ' process
@@ -218,9 +218,9 @@ End Function
 Public Function save_record(obj_kpi_on_time_result_client As KPIOnTimeResultClient, rg_record As Range)
     ' date and time
     rg_record.Offset(0, INT_OFFSET_DATE).NumberFormat = "@"
-    rg_record.Offset(0, INT_OFFSET_DATE).Value = obj_kpi_on_time_result_client.str_date
+    rg_record.Offset(0, INT_OFFSET_DATE).Value = Format(obj_kpi_on_time_result_client.str_date, "DD.MM.YY")
     rg_record.Offset(0, INT_OFFSET_TIME).NumberFormat = "@"
-    rg_record.Offset(0, INT_OFFSET_TIME).Value = obj_kpi_on_time_result_client.str_time
+    rg_record.Offset(0, INT_OFFSET_TIME).Value = Format(obj_kpi_on_time_result_client.str_time, "hh:mm")
     ' shift
     rg_record.Offset(0, INT_OFFSET_SHIFT).Value = obj_kpi_on_time_result_client.str_shift
     ' process

--- a/modules-classes/app_dashboard.bas
+++ b/modules-classes/app_dashboard.bas
@@ -47,7 +47,7 @@ Public Function run()
     ' run setting
     obj_dashboard.bool_run_process = new_const_ctrl_dashboard1.BOOL_RUN_PROCESS_YES
     obj_dashboard.bool_run_kpi_pallet = new_const_ctrl_dashboard1.BOOL_RUN_KPI_PALLET_YES
-    obj_dashboard.bool_run_kpi_result = new_const_ctrl_dashboard1.BOOL_RUN_KPI_RESULT_NO
+    obj_dashboard.bool_run_kpi_result = new_const_ctrl_dashboard1.BOOL_RUN_KPI_RESULT_YES
     
     obj_dashboard.before_run
     obj_dashboard.run


### PR DESCRIPTION
MDLKPIOnTimeResultClient
- for better readability of date and time in client shared file with client contains short date and time format
- during loading from shared file must be date and time converted back to long version of date and time because app works with it internally
app_dashboard
- KPI_RESULT switch is turned on - forgotten setup for production run