### PR TITLE
Bug #67

### DIFF
--- a/modules-classes/CtrlKPIOnTimePallet.cls
+++ b/modules-classes/CtrlKPIOnTimePallet.cls
@@ -119,6 +119,9 @@ Public Function process_db_data_process_record(obj_data_process As DBDataProcess
         Set obj_kpi_on_time_pallet = col_kpi_pallets(obj_data_process.str_pallet)
         On Error GoTo 0
         
+        ' set synchronization status with data process records
+        obj_kpi_on_time_pallet.bool_is_synchronized_with_process = True
+        
         If Not obj_kpi_on_time_pallet.obj_checkpoint Is Nothing Then ' check to not process pallets which already reached final checkpoint
             Set obj_kpi_on_time_pallet_steps = update_kpi_on_time_pallet(obj_kpi_on_time_pallet, obj_data_process)
             process_steps obj_kpi_on_time_pallet_steps, col_kpi_intervals
@@ -560,16 +563,14 @@ End Function
 ' Processing of unfinished pallets
 Public Function save_unfinished(obj_provider_info As FileExcelDataProviderInfo)
     Dim obj_pallet As KPIOnTimePallet
-    Dim obj_pallet_valid_places As KPIOnTimePallet
 
     For Each obj_pallet In col_kpi_pallets
         ' find out if pallet should be saved into unfinished
         On Error GoTo ERR_TEST
-        If Not obj_pallet.obj_checkpoint.obj_next_limit Is Nothing Then
-'            Set obj_pallet_valid_places = obj_pallet.create_copy
-'            update_pallet_step_places obj_pallet_valid_places, False
-'            obj_mdl_kpi_on_time_pallet_unfinished.save_record_static obj_pallet_valid_places
-            obj_mdl_kpi_on_time_pallet_unfinished.save_record_static obj_pallet
+        If obj_pallet.bool_is_synchronized_with_process Then
+            If Not obj_pallet.obj_checkpoint.obj_next_limit Is Nothing Then
+                obj_mdl_kpi_on_time_pallet_unfinished.save_record_static obj_pallet
+            End If
         End If
         On Error GoTo 0
     Next
@@ -590,6 +591,8 @@ Public Function kpi_pallet_process_record(obj_kpi_on_time_pallet As KPIOnTimePal
     ' register pallet
     On Error GoTo WARN_PALLET_ALREADY_EXISTS
     Set obj_kpi_on_time_pallet.obj_checkpoint = retrieve_checkpoint(obj_kpi_on_time_pallet)
+    ' set pallet synchronization status
+    obj_kpi_on_time_pallet.bool_is_synchronized_with_process = False
     col_kpi_pallets.add obj_kpi_on_time_pallet, obj_kpi_on_time_pallet.str_id
     On Error GoTo 0
 

--- a/modules-classes/KPIOnTimePallet.cls
+++ b/modules-classes/KPIOnTimePallet.cls
@@ -38,6 +38,8 @@ Public str_process_status As String
 Public byte_process_status As Byte
 Public private_bool_status_ok As Boolean
 
+Public bool_is_synchronized_with_process As Boolean
+
 Public Property Get bool_status_ok() As Boolean
     bool_status_ok = retrieve_actual_duration <= obj_checkpoint.obj_limit
 End Property
@@ -91,3 +93,7 @@ Public Function toString() As String
     CStr(private_bool_status_ok) & const_separator.SEPARATOR_CLASS_ELEMENT
     
 End Function
+
+Private Sub Class_Initialize()
+    bool_is_synchronized_with_process = True
+End Sub

--- a/modules-classes/MDLKPIOnTimeResultClient.cls
+++ b/modules-classes/MDLKPIOnTimeResultClient.cls
@@ -73,6 +73,8 @@ Private Sub Class_Initialize()
     Set col_listeners = New Collection
     
     str_datetime_shift_separator = "-"
+    
+    str_id = str_module
 End Sub
 
 Public Function set_clear_data()
@@ -128,7 +130,7 @@ Public Function load_record(rg_record As Range)
       ' date and time
     'obj_kpi_on_time_result_client.str_date = Format(rg_record.Offset(0, INT_OFFSET_DATE).Value, "DD.MM.YYYY")
     obj_kpi_on_time_result_client.str_date = Format(rg_record.Offset(0, INT_OFFSET_DATE).Value, "D.M.YYYY")
-    obj_kpi_on_time_result_client.str_time = Format(rg_record.Offset(0, INT_OFFSET_TIME).Value, "hh:mm:ss")
+    obj_kpi_on_time_result_client.str_time = Format(rg_record.Offset(0, INT_OFFSET_TIME).Value, "h:mm:ss")
       ' shift
     obj_kpi_on_time_result_client.str_shift = rg_record.Offset(0, INT_OFFSET_SHIFT).Value
       ' process


### PR DESCRIPTION
Fixes #67
- fix works just partly, there's case when pallet looks like is delivered late
  - it happens when in previous hour pallet is picked, in next depicked and again picked. In this case the pallet start time is the time of first pick
  - need to create new issue
- fix made synchronization between data process and kpi pallet
  - if data process doesn't contain any longer specific pallet then kpi pallet record must disappear too.
  - kpi pallet has new attribute bool_is_synchronized_with_process
  - when kpi pallet is loaded from kpi unfinished pallet record then bool_is_synchronized_with_process is set to false and waits if processed file of data process still contains this pallet

MDLKPIOnTimeResultClient
- resolved bug with time format
- create issue to check time and date formats in all modules